### PR TITLE
improving parameter handling

### DIFF
--- a/transformato/mutate.py
+++ b/transformato/mutate.py
@@ -1519,14 +1519,7 @@ class CommonCoreTransformation(object):
             # compare to charge compenstated psf 2
             for ligand2_atom in self.charge_compensated_ligand2_psf:
                 # Assure that only atoms from the same resdiue are compared, and only atoms belonging to the same chain!
-                if (
-                    self.atom_names_mapping[ligand1_atom.name] == ligand2_atom.name
-                    and ligand1_atom.residue.name == ligand2_atom.residue.name
-                    and ligand1_atom.type == ligand2_atom.type
-                    and len(ligand1_atom.residue.atoms)
-                    == len(ligand2_atom.residue.atoms)
-                    and ligand1_atom.residue.chain == ligand2_atom.residue.chain
-                ):
+                if self.atom_names_mapping[ligand1_atom.name] == ligand2_atom.name and ligand1_atom.residue.name == ligand2_atom.residue.name and ligand1_atom.type == ligand2_atom.type and len(ligand1_atom.residue.atoms) == len(ligand2_atom.residue.atoms) and ligand1_atom.residue.chain == ligand2_atom.residue.chain:
                     found = True
                     # are the atoms different?
                     logger.debug(f"Modifying atom: {ligand1_atom}")
@@ -1545,13 +1538,7 @@ class CommonCoreTransformation(object):
                 try:
                     for ligand2_atom in self.charge_compensated_ligand2_psf:
                         # make sure resdiue PSU which is like CYT are nevertheless found
-                        if (
-                            self.atom_names_mapping[ligand1_atom.name]
-                            == ligand2_atom.name
-                            and len(ligand1_atom.residue.atoms)
-                            == len(ligand2_atom.residue.atoms)
-                            and ligand1_atom.residue.chain == ligand2_atom.residue.chain
-                        ):
+                        if self.atom_names_mapping[ligand1_atom.name] == ligand2_atom.name and len(ligand1_atom.residue.atoms) == len(ligand2_atom.residue.atoms) and ligand1_atom.residue.chain == ligand2_atom.residue.chain:
                             found = True
                             # are the atoms different?
                             print(f"Modifying atom: {ligand1_atom}")

--- a/transformato/mutate.py
+++ b/transformato/mutate.py
@@ -1519,7 +1519,14 @@ class CommonCoreTransformation(object):
             # compare to charge compenstated psf 2
             for ligand2_atom in self.charge_compensated_ligand2_psf:
                 # Assure that only atoms from the same resdiue are compared, and only atoms belonging to the same chain!
-                if self.atom_names_mapping[ligand1_atom.name] == ligand2_atom.name and ligand1_atom.residue.name == ligand2_atom.residue.name and ligand1_atom.type == ligand2_atom.type and len(ligand1_atom.residue.atoms) == len(ligand2_atom.residue.atoms) and ligand1_atom.residue.chain == ligand2_atom.residue.chain:
+                if (
+                    self.atom_names_mapping[ligand1_atom.name] == ligand2_atom.name
+                    and ligand1_atom.residue.name == ligand2_atom.residue.name
+                    and ligand1_atom.type == ligand2_atom.type
+                    and len(ligand1_atom.residue.atoms)
+                    == len(ligand2_atom.residue.atoms)
+                    and ligand1_atom.residue.chain == ligand2_atom.residue.chain
+                ):
                     found = True
                     # are the atoms different?
                     logger.debug(f"Modifying atom: {ligand1_atom}")
@@ -1538,7 +1545,13 @@ class CommonCoreTransformation(object):
                 try:
                     for ligand2_atom in self.charge_compensated_ligand2_psf:
                         # make sure resdiue PSU which is like CYT are nevertheless found
-                        if self.atom_names_mapping[ligand1_atom.name] == ligand2_atom.name and len(ligand1_atom.residue.atoms) == len(ligand2_atom.residue.atoms) and ligand1_atom.residue.chain == ligand2_atom.residue.chain:
+                        if (
+                            self.atom_names_mapping[ligand1_atom.name]
+                            == ligand2_atom.name
+                            and len(ligand1_atom.residue.atoms)
+                            == len(ligand2_atom.residue.atoms)
+                            and ligand1_atom.residue.chain == ligand2_atom.residue.chain
+                        ):
                             found = True
                             # are the atoms different?
                             print(f"Modifying atom: {ligand1_atom}")

--- a/transformato/state.py
+++ b/transformato/state.py
@@ -1031,7 +1031,6 @@ cutnb 14.0 ctofnb 12.0 ctonnb 10.0 eps 1.0 e14fac 1.0 wmin 1.5"""
 
     def _write_toppar_str(self, output_file_base):
 
-
         from transformato.system import parameter_files
 
         base = "../../toppar"

--- a/transformato/state.py
+++ b/transformato/state.py
@@ -1031,35 +1031,17 @@ cutnb 14.0 ctofnb 12.0 ctonnb 10.0 eps 1.0 e14fac 1.0 wmin 1.5"""
 
     def _write_toppar_str(self, output_file_base):
 
-        toppar_format = f"""
-../../toppar/top_all36_prot.rtf
-../../toppar/par_all36m_prot.prm
-../../toppar/top_all36_na.rtf
-../../toppar/par_all36_na.prm
-../../toppar/top_all36_carb.rtf
-../../toppar/par_all36_carb.prm
-../../toppar/top_all36_lipid.rtf
-../../toppar/par_all36_lipid.prm
-../../toppar/top_all36_cgenff.rtf
-../../toppar/par_all36_cgenff.prm
-../../toppar/toppar_water_ions.str
-../../toppar/toppar_dum_noble_gases.str
-../../toppar/toppar_all36_prot_c36m_d_aminoacids.str
-../../toppar/toppar_all36_prot_fluoro_alkanes.str
-../../toppar/toppar_all36_prot_heme.str
-../../toppar/toppar_all36_prot_na_combined.str
-../../toppar/toppar_all36_prot_retinol.str
-../../toppar/toppar_all36_na_nad_ppi.str
-../../toppar/toppar_all36_lipid_bacterial.str
-../../toppar/toppar_all36_lipid_cardiolipin.str
-../../toppar/toppar_all36_lipid_cholesterol.str
-../../toppar/toppar_all36_lipid_inositol.str
-../../toppar/toppar_all36_lipid_lps.str
-../../toppar/toppar_all36_lipid_miscellaneous.str
-../../toppar/toppar_all36_lipid_model.str
-../../toppar/toppar_all36_lipid_prot.str
-../../toppar/toppar_all36_lipid_sphingo.str
-"""
+        from transformato.system import parameter_files
+
+        base = "../../toppar"
+        toppar_format = ""
+        for i in parameter_files:
+            # the parameterfiles for customized ligands are in another directory and are considered below
+            if self.system.tlc.lower() in i:
+                pass
+            else:
+                toppar_format += f"{base}/{i.split('/')[-1]} \n"
+
         if os.path.isfile(
             f"{self.system.charmm_gui_base}/waterbox/{self.system.tlc.lower()}/{self.system.tlc.lower()}_g.rtf"
         ):

--- a/transformato/state.py
+++ b/transformato/state.py
@@ -1034,12 +1034,20 @@ cutnb 14.0 ctofnb 12.0 ctonnb 10.0 eps 1.0 e14fac 1.0 wmin 1.5"""
         from transformato.system import parameter_files
         base = "../../toppar"
         toppar_format = ""
+        # Only necessary because the variable self.configuration["system"]["structure2"]["tlc"] gives a keyError for asfe
+        # since its not defined there
+        try:
+            if self.configuration["system"]["structure2"]["tlc"].lower():
+                struct2 = self.configuration["system"]["structure2"]["tlc"].lower()
+        except KeyError:
+            struct2 = "emptyString"
+
         for i in parameter_files:
             # the parameterfiles for customized ligands are in another directory and are considered below
             if self.configuration["system"]["structure1"]["tlc"].lower() in i:
                 pass
-            elif self.configuration["system"]["structure2"]["tlc"].lower() in i:
-                pass            
+            if struct2 in i:
+                pass
             else:
                 toppar_format += f"{base}/{i.split('/')[-1]} \n"
 

--- a/transformato/state.py
+++ b/transformato/state.py
@@ -1032,13 +1032,14 @@ cutnb 14.0 ctofnb 12.0 ctonnb 10.0 eps 1.0 e14fac 1.0 wmin 1.5"""
     def _write_toppar_str(self, output_file_base):
 
         from transformato.system import parameter_files
-
         base = "../../toppar"
         toppar_format = ""
         for i in parameter_files:
             # the parameterfiles for customized ligands are in another directory and are considered below
-            if self.system.tlc.lower() in i:
+            if self.configuration["system"]["structure1"]["tlc"].lower() in i:
                 pass
+            elif self.configuration["system"]["structure2"]["tlc"].lower() in i:
+                pass            
             else:
                 toppar_format += f"{base}/{i.split('/')[-1]} \n"
 

--- a/transformato/state.py
+++ b/transformato/state.py
@@ -1032,6 +1032,7 @@ cutnb 14.0 ctofnb 12.0 ctonnb 10.0 eps 1.0 e14fac 1.0 wmin 1.5"""
     def _write_toppar_str(self, output_file_base):
 
         from transformato.system import parameter_files
+
         base = "../../toppar"
         toppar_format = ""
         # Only necessary because the variable self.configuration["system"]["structure2"]["tlc"] gives a keyError for asfe

--- a/transformato/state.py
+++ b/transformato/state.py
@@ -628,12 +628,12 @@ with open(file_name + '_system.xml','w') as outfile:
 
         basedir = self.system.charmm_gui_base
 
-        try:
-            self._copy_ligand_specific_top_and_par(
-                basedir, intermediate_state_file_path
-            )
-        except:
-            self._copy_ligand_specific_str(basedir, intermediate_state_file_path)
+        # try:
+        #     self._copy_ligand_specific_top_and_par(
+        #         basedir, intermediate_state_file_path
+        #     )
+        # except:
+        #     self._copy_ligand_specific_str(basedir, intermediate_state_file_path)
 
         # copy crd file
         self._copy_crd_file((intermediate_state_file_path))
@@ -1031,6 +1031,7 @@ cutnb 14.0 ctofnb 12.0 ctonnb 10.0 eps 1.0 e14fac 1.0 wmin 1.5"""
 
     def _write_toppar_str(self, output_file_base):
 
+
         from transformato.system import parameter_files
 
         base = "../../toppar"
@@ -1060,9 +1061,15 @@ cutnb 14.0 ctofnb 12.0 ctonnb 10.0 eps 1.0 e14fac 1.0 wmin 1.5"""
 dummy_atom_definitions.rtf
 dummy_parameters.prm
 """
-        else:
+        elif os.path.isfile(
+            f"{self.system.charmm_gui_base}/waterbox/{self.system.tlc.lower()}/{self.system.tlc.lower()}.str"
+        ):
             toppar_format += f"""{self.system.tlc.lower()}.str
 dummy_atom_definitions.rtf
+dummy_parameters.prm
+"""
+        else:
+            toppar_format += f"""dummy_atom_definitions.rtf
 dummy_parameters.prm
 """
 
@@ -1092,7 +1099,7 @@ dummy_parameters.prm
         psf.write_psf(string_object)
         # read in psf and correct some aspects of the file not suitable for CHARMM
         corrected_psf = psf_correction(string_object)
-        with open(f"{output_file_base}/lig_in_{env}_corr.psf", "w+") as f:
+        with open(f"{output_file_base}/lig_in_{env}.psf", "w+") as f:
             f.write(corrected_psf)
         # write pdb
         psf.write_pdb(f"{output_file_base}/lig_in_{env}.pdb")

--- a/transformato/system.py
+++ b/transformato/system.py
@@ -162,10 +162,14 @@ class SystemStructure(object):
 
         # check if toppar dir is available in CHARMM-GUI folder, if not fall back to toppar dir from transformato
         if os.path.isdir(toppar_dir):
-            logger.info(f"Using the toppar directory from the CHARMM-GUI folder; {toppar_dir}")
+            logger.info(
+                f"Using the toppar directory from the CHARMM-GUI folder; {toppar_dir}"
+            )
         else:
             toppar_dir = get_toppar_dir()
-            logger.info(f"Using the toppar directory provided in the transformato package; {toppar_dir}")
+            logger.info(
+                f"Using the toppar directory provided in the transformato package; {toppar_dir}"
+            )
 
         # if custom parameter are added they are located in l1,l2
         l1 = f"{charmm_gui_env}/{tlc_lower}/{tlc_lower}.rtf"

--- a/transformato/system.py
+++ b/transformato/system.py
@@ -56,20 +56,18 @@ class SystemStructure(object):
                 parameter = self._read_parameters(env)
                 self.psfs[env].load_parameters(parameter)
             except pm.exceptions.ParameterError:
-                parameter = self._read_parameters(env, full_set = True)
+                parameter = self._read_parameters(env, full_set=True)
                 self.psfs[env].load_parameters(parameter)
 
             # get offset
-            self.offset[
-                env
-            ] = self._determine_offset_and_set_possible_dummy_properties(
+            self.offset[env] = self._determine_offset_and_set_possible_dummy_properties(
                 self.psfs[env]
             )
 
         # generate rdkit mol object of small molecule
         self.mol: Chem.Mol = self._generate_rdkit_mol(
             "waterbox", self.psfs["waterbox"][f":{self.tlc}"]
-        ) # for RBFE this was called "complex"
+        )  # for RBFE this was called "complex"
         self.graph: nx.Graph = self.mol_to_nx(self.mol)
 
         # For RBFE:
@@ -134,7 +132,9 @@ class SystemStructure(object):
 
             return G
 
-    def _read_parameters(self, env: str, full_set: bool = False) -> pm.charmm.CharmmParameterSet:
+    def _read_parameters(
+        self, env: str, full_set: bool = False
+    ) -> pm.charmm.CharmmParameterSet:
         """
         Reads in topparameters from a toppar dir and ligand specific parameters.
         Parameters
@@ -194,12 +194,12 @@ class SystemStructure(object):
                 for line in ommtopparstream:
                     if tlc_lower:
                         if line.strip() != "" and not tlc_lower in line:
-                            filename = line.strip('\n').split('/')[-1]
-                            parameter_files += (f"{toppar_dir}/{filename}", )
+                            filename = line.strip("\n").split("/")[-1]
+                            parameter_files += (f"{toppar_dir}/{filename}",)
                     else:
                         if line.strip() != "":
-                            filename = line.strip('\n').split('/')[-1]
-                            parameter_files += (f"{toppar_dir}/{filename}", )
+                            filename = line.strip("\n").split("/")[-1]
+                            parameter_files += (f"{toppar_dir}/{filename}",)
 
         else:
             parameter_files += (f"{toppar_dir}/top_all36_prot.rtf",)

--- a/transformato/system.py
+++ b/transformato/system.py
@@ -32,7 +32,7 @@ class SystemStructure(object):
         self.charmm_gui_base: str = configuration["system"][structure]["charmm_gui_dir"]
         self.psfs: defaultdict = defaultdict(pm.charmm.CharmmPsfFile)
         self.offset: defaultdict = defaultdict(int)
-        self.parameter = self._read_parameters("waterbox")
+        # self.parameter = self._read_parameters("waterbox")
         self.cgenff_version: float
         self.envs = set()
         # running a binding-free energy calculation?
@@ -60,6 +60,7 @@ class SystemStructure(object):
                 self.psfs[env].load_parameters(parameter)
 
             # get offset
+            self.tlc = "GUA:CYT:URA:PSU"  # TODO: find better solution!
             self.offset[env] = self._determine_offset_and_set_possible_dummy_properties(
                 self.psfs[env]
             )
@@ -334,10 +335,44 @@ class SystemStructure(object):
 
         return min(idx_list)
 
+    def _create_sdf_file(self) -> str:
+
+        file_path = f"{self.charmm_gui_base}/waterbox/openmm/"
+
+        pdb = pm.read_PDB(f"{file_path}/step3_input.pdb")
+
+        deletedatoms = 0
+        atomid = 0
+        length = len(pdb.atoms)
+        while deletedatoms + atomid < length:
+            if pdb.atoms[atomid].residue.segid != "RNAA":
+                pdb.atoms.remove(pdb.atoms[atomid])
+                deletedatoms += 1
+            else:
+                atomid += 1
+
+        pdb.write_pdb(f"{file_path}/step3_input_tmp.pdb")
+
+        from openbabel import openbabel
+
+        obConversion = openbabel.OBConversion()
+        obConversion.SetInAndOutFormats("pdb", "sdf")
+        mol = openbabel.OBMol()
+        obConversion.ReadFile(mol, f"{file_path}/step3_input_tmp.pdb")
+        obConversion.WriteFile(mol, f"{file_path}/step3_input_reduced.sdf")
+
+        return f"{file_path}/step3_input_reduced.sdf"
+
+    def _return_strand(self):
+
+        sdf_file = self._create_sdf_file()
+
+        suppl = Chem.SDMolSupplier
+
     def _return_small_molecule(self, env: str) -> Chem.rdchem.Mol:
         import glob
 
-        charmm_gui_env = self.charmm_gui_base + env
+        charmm_gui_env = self.charmm_gui_base + "waterbox"
         possible_files = []
         for ending in ["sdf", "mol", "mol2"]:
             possible_files.extend(glob.glob(f"{charmm_gui_env}/*/*{ending}"))
@@ -384,6 +419,12 @@ class SystemStructure(object):
         """
 
         assert type(psf) == pm.charmm.CharmmPsfFile
+
+        try:
+            self._return_strand()
+        except:
+            pass
+
         mol = self._return_small_molecule(env)
         (
             atom_idx_to_atom_name,

--- a/transformato/system.py
+++ b/transformato/system.py
@@ -148,6 +148,9 @@ class SystemStructure(object):
         parameter : pm.charmm.CharmmParameterSet
             parameters obtained from the CHARMM-GUI output dir.
         """
+        # save list of files for creation of toppar.str
+        global parameter_files
+        parameter_files = tuple()
 
         # the parameters for the vacuum system is parsed from the waterbox charmm-gui directory
         if env == "vacuum":
@@ -157,14 +160,14 @@ class SystemStructure(object):
         tlc_lower = str(self.tlc).lower()
         toppar_dir = f"{charmm_gui_env}/toppar"
 
-        # check if toppar dir is available in CHARMM-GU folder, if not fall back to toppar dir from transformato
+        # check if toppar dir is available in CHARMM-GUI folder, if not fall back to toppar dir from transformato
         if os.path.isdir(toppar_dir):
-            pass
+            logger.info(f"Using the toppar directory from the CHARMM-GUI folder; {toppar_dir}")
         else:
             toppar_dir = get_toppar_dir()
+            logger.info(f"Using the toppar directory provided in the transformato package; {toppar_dir}")
 
         # if custom parameter are added they are located in l1,l2
-        parameter_files = tuple()
         l1 = f"{charmm_gui_env}/{tlc_lower}/{tlc_lower}.rtf"
         l2 = f"{charmm_gui_env}/{tlc_lower}/{tlc_lower}.prm"
         l3 = f"{charmm_gui_env}/{tlc_lower}/{tlc_lower}.str"

--- a/transformato/tests/test_point_mutation.py
+++ b/transformato/tests/test_point_mutation.py
@@ -1,0 +1,72 @@
+# Import package, test suite, and other packages as needed
+import logging
+import os
+import warnings
+from io import StringIO
+import pdb
+import parmed as pm
+import pytest
+
+# read in specific topology with parameters
+# read in specific topology with parameters
+from transformato import (
+    SystemStructure,
+    IntermediateStateFactory,
+    ProposeMutationRoute,
+    load_config_yaml,
+    psf_correction,
+)
+from transformato.mutate import perform_mutations
+from transformato.tests.paths import get_test_output_dir
+from transformato_testsystems.testsystems import get_testsystems_dir
+
+warnings.filterwarnings("ignore", module="parmed")
+
+
+# @pytest.mark.rbfe
+# @pytest.mark.requires_parmed_supporting_lp
+# @pytest.mark.skipif(
+#     os.getenv("CI") == "true",
+#     reason="Skipping tests that cannot pass in github actions",
+# )
+def test_setting_up_point_mutation():
+
+    configuration = load_config_yaml(
+        config=f"/site/raid3/johannes/bioinfo/cano2_modif2.yaml",
+        input_dir="/site/raid3/johannes/bioinfo",
+        output_dir="/site/raid3/johannes/bioinfo",
+    )
+
+    # pdb.set_trace()
+    s1 = SystemStructure(configuration, "structure1")
+    s2 = SystemStructure(configuration, "structure2")
+    s1_to_s2 = ProposeMutationRoute(s1, s2)
+    s1_to_s2.propose_common_core()
+    s1_to_s2.finish_common_core()
+
+    mutation_list = s1_to_s2.generate_mutations_to_common_core_for_mol1()
+    i = IntermediateStateFactory(
+        system=s1,
+        configuration=configuration,
+    )
+
+    perform_mutations(
+        configuration=configuration,
+        nr_of_mutation_steps_charge=3,
+        nr_of_mutation_steps_cc=3,
+        i=i,
+        mutation_list=mutation_list,
+    )
+
+    mutation_list = s1_to_s2.generate_mutations_to_common_core_for_mol2()
+    i = IntermediateStateFactory(
+        system=s2,
+        configuration=configuration,
+    )
+
+    perform_mutations(
+        configuration=configuration,
+        nr_of_mutation_steps_charge=3,
+        i=i,
+        mutation_list=mutation_list,
+    )


### PR DESCRIPTION
## Description
Sometimes more parameters are needed for a system than we currently add hard coded. I suggest, in cases where the hardcoded parameter files are not enough, we fall back to reading the `toppar.str` file provided by CHARMM-GUI and use all parameters there (this slows down transformato but otherwise we would always need to check which parameter file is missing)

## Todos
  - [ ] Now we are reading in all parameters but are not yet writing them out for the ongoing simulation