### PR TITLE
Avoid using python=3.12 for the moment

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -47,7 +47,7 @@ jobs:
           #  miniforge-variant: Mambaforge-pypy3
 
     steps:
-    - uses: actions/checkout@v4.1.1
+    - uses: actions/checkout@v4.1.6
 
     - name: Additional info about the build
       shell: bash
@@ -61,7 +61,7 @@ jobs:
       
     - name: Make Cache (no worflow_dispatch)
       if: ${{ github.event_name != 'workflow_dispatch' }}
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4.0.2
       with:
         path: ~/conda_pkgs_dir # ${{ matrix.prefix }}
         # Increase the last number (0) to reset cache manually
@@ -70,7 +70,7 @@ jobs:
       
     - name: Make Cache (worflow_dispatch)
       if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/cache@v3.3.2
+      uses: actions/cache@v4.0.2
       with:
         path: ~/conda_pkgs_dir # ${{ matrix.prefix }}
         key: ${{ matrix.label }}-conda-${{ hashFiles('devtools/conda-envs/fep_env.yaml') }}-${{ env.DATE }}-${{ inputs.CACHE_NUMBER }}
@@ -78,7 +78,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v3.0.1
+    - uses: conda-incubator/setup-miniconda@v3.0.4
       with:
         python-version: ${{ matrix.python-version }}
         condarc-file: ${{ matrix.condarc-file }}
@@ -122,7 +122,7 @@ jobs:
         pytest -v --cov=transformato --cov-report=xml --color=yes transformato/tests/
 
     - name: CodeCov
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v4.4.1
       with:
         file: ./coverage.xml
         flags: unittests

--- a/devtools/conda-envs/fep_env.yaml
+++ b/devtools/conda-envs/fep_env.yaml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   # Base depends
   - openmm
+  - python=3.11
   - openmmtools
   - numpy
   - ipython

--- a/devtools/conda-envs/fep_env.yaml
+++ b/devtools/conda-envs/fep_env.yaml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # Base depends
   - openmm
-  - python=3.11
+  - python<3.12
   - openmmtools
   - numpy
   - ipython

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ max-line-length = 119
 [versioneer]
 # Automatic version numbering scheme
 VCS = git
-style = pep440-pre
+style = pep440
 versionfile_source = transformato/_version.py
 versionfile_build = transformato/_version.py
 tag_prefix = ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ max-line-length = 119
 [versioneer]
 # Automatic version numbering scheme
 VCS = git
-style = pep440
+style = pep440-pre
 versionfile_source = transformato/_version.py
 versionfile_build = transformato/_version.py
 tag_prefix = ''


### PR DESCRIPTION
For some reason `versioneer.py`does not work together with python3.12. For now I restricted the python version to below 3.12